### PR TITLE
Fix message format for triggering builds

### DIFF
--- a/build_pipeline/helpers.py
+++ b/build_pipeline/helpers.py
@@ -149,7 +149,7 @@ def publish_sns_messsage(topic_arn, message):
         string: The MessageId of the published message
 
     Raises:
-        SnsError when publising was unsuccessful
+        SnsError when publishing was unsuccessful
     """
     try:
         LOGGER.debug('Publishing to {}. Message is {}'.format(topic_arn, message))
@@ -187,14 +187,12 @@ def _compose_sns_message(repo_org, repo_name):
     from the SQS Queue and trigger any jobs that have a matching github repository configuration.
 
     """
-    message = {}
     repo = {}
     repo['name'] = repo_name
     repo['owner'] = {'name': '{org}'.format(org=repo_org)}
     repo['url'] = 'https://github.com/{org}/{name}'.format(org=repo_org, name=repo_name)
-    message['default'] = "{}".format(json.dumps(repo))
-
-    return message
+    repository = {'repository': repo}
+    return repository
 
 
 def handle_deployment_event(topic, repo_org, repo_name, deployment):

--- a/build_pipeline/test/test_helpers.py
+++ b/build_pipeline/test/test_helpers.py
@@ -37,7 +37,7 @@ class ComposeTestCase(TestCase):
         msg = _compose_sns_message('org', 'repo')
         self.assertEqual(
             msg,
-            {'default': '{"owner": {"name": "org"}, "url": "https://github.com/org/repo", "name": "repo"}'}
+            {"repository": {"owner": {"name": "org"}, "url": "https://github.com/org/repo", "name": "repo"}}
         )
 
 


### PR DESCRIPTION
@benpatterson 
The json that the jenkins SQS plugin needed was off - it needed one more layer, to be under the key "repository"

Was: 

```
{'default': '{"owner": {"name": "org"}, "url": "https://github.com/org/repo", "name": "repo"}'}
```

Should have been:

```
{'default': '{"repository": {"owner": {"name": "org"}, "url": "https://github.com/org/repo", "name": "repo"}}'}
```
